### PR TITLE
Allow semicolon

### DIFF
--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -16,6 +16,8 @@ Style/EmptyLinesAroundMethodBody:
   Enabled: false
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
+Style/Semicolon:
+  AllowAsExpressionSeparator: true
 
 TrailingComma:
   Enabled: true


### PR DESCRIPTION
I think that semicolon make sense in one-line injects

eg `fields.inject({}) { |r, f| r[f.to_sym] = nil; r }`
