### PR TITLE
Add method for using reevoocop on legacy projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ require 'reevoocop/rake_task'
 ReevooCop::RakeTask.new(:reevoocop)
 ```
 
+Or to only have it lint files from this point forwards:
+
+Where the commit hash is the has of the latest commit.
+
+```ruby
+task :reevoocop do
+  sh "reevoocop #{files_that_changed_since_t_minus_0}"
+end
+
+def files_that_changed_since_t_minus_0
+  `git diff-tree --no-commit-id --name-only -r 19c297ff4a91b47c9af735a935c72ea5a2f05791 HEAD`
+    .split("\n").select { |f| f.match(/(rb\z)|Rakefile/) }.join(' ')
+end
+```
+
 In your shell
 ```
 $ reevoocop


### PR DESCRIPTION
This is going to become your least favourite bit of code. :speak_no_evil: 
