### PR TITLE
Allow multi-line block chaining

### DIFF
--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -26,6 +26,9 @@ TrailingComma:
     - comma
     - no_comma
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 AllCops:
   Exclude:
     - !ruby/regexp /node_modules/


### PR DESCRIPTION
What do we think about allowing multi-line block chaining?

``` ruby
my_array.map do |e|
  something(e)
end.group_by do |e|
  e.whatever
end
```
