### PR TITLE
Update style guides with recent developer preferences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in reevoocop.gemspec
 gemspec
 
-gem 'pry'
+gem "pry"

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 # encoding: utf-8
 
-require 'bundler/gem_tasks'
-require 'reevoocop/rake_task'
+require "bundler/gem_tasks"
+require "reevoocop/rake_task"
 
 ReevooCop::RakeTask.new(:reevoocop)
 
 task :reevoocop_cli do
-  sh 'bin/reevoocop'
+  sh "bin/reevoocop"
 end
 
 task default: [:reevoocop, :reevoocop_cli]

--- a/bin/reevoocop
+++ b/bin/reevoocop
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 
-$LOAD_PATH.unshift(File.dirname(File.realpath(__FILE__)) + '/../lib')
+$LOAD_PATH.unshift(File.dirname(File.realpath(__FILE__)) + "/../lib")
 
-require 'reevoocop'
-require 'benchmark'
+require "reevoocop"
+require "benchmark"
 
 cli = RuboCop::CLI.new
 result = 0

--- a/lib/reevoocop.rb
+++ b/lib/reevoocop.rb
@@ -1,12 +1,12 @@
 # encoding: utf-8
 
-require 'rubocop'
+require "rubocop"
 
 module RuboCop
   class ConfigLoader
     class << self
       def configuration_file_for(_target_dir)
-        File.join(File.realpath(File.dirname(__FILE__)), 'reevoocop.yml')
+        File.join(File.realpath(File.dirname(__FILE__)), "reevoocop.yml")
       end
     end
   end

--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -15,12 +15,28 @@ AndOr:
 # Allow use of empty lines to visually group code into 'paragraphs'
 EmptyLines:
   Enabled: false
+
+# Keeping parameters in a line makes them easier to read, but in long lines the
+# parameters look ridiculous if using the "with_first_parameter" option, making
+# it more difficult to read the code
+Style/AlignParameters: with_fixed_indentation
+
+# Blank lines are useful in separating methods, specs, etc. from one another,
+# and improves the aesthetics of the code. Consequently, we've enabled
+# EmptyLines around blocks and methods. This is less desirable for Classes and
+# Modules where the definitions may be usefully put on consecutive lines, e.g.:
+#
+# module API
+#   module Auth
+#     class Person
+# ... etc
+#
 Style/EmptyLinesAroundBlockBody:
-  Enabled: false
+  Enabled: true
 Style/EmptyLinesAroundClassBody:
   Enabled: false
 Style/EmptyLinesAroundMethodBody:
-  Enabled: false
+  Enabled: true
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
 
@@ -28,6 +44,12 @@ Style/EmptyLinesAroundModuleBody:
 # See https://github.com/reevoo/reevoocop/issues/10
 Style/ModuleFunction:
   Enabled: false
+
+# See more here: https://viget.com/extend/just-use-double-quoted-ruby-strings
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
 
 # See https://github.com/reevoo/reevoocop/issues/1
 # * For cleaner git diffs

--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -19,7 +19,8 @@ EmptyLines:
 # Keeping parameters in a line makes them easier to read, but in long lines the
 # parameters look ridiculous if using the "with_first_parameter" option, making
 # it more difficult to read the code
-Style/AlignParameters: with_fixed_indentation
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
 
 # Blank lines are useful in separating methods, specs, etc. from one another,
 # and improves the aesthetics of the code. Consequently, we've enabled

--- a/lib/reevoocop/rake_task.rb
+++ b/lib/reevoocop/rake_task.rb
@@ -1,11 +1,11 @@
 # encoding: utf-8
 
-require 'rubocop/rake_task'
+require "rubocop/rake_task"
 
 module ReevooCop
   class RakeTask < RuboCop::RakeTask
     def run_cli(verbose, options)
-      require 'reevoocop'
+      require "reevoocop"
       super(verbose, options)
     end
   end

--- a/lib/reevoocop/version.rb
+++ b/lib/reevoocop/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module ReevooCop
-  VERSION = '0.0.6'
+  VERSION = "0.0.6"
 end

--- a/reevoocop.gemspec
+++ b/reevoocop.gemspec
@@ -1,24 +1,24 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'reevoocop/version'
+require "reevoocop/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'reevoocop'
+  spec.name          = "reevoocop"
   spec.version       = ReevooCop::VERSION
-  spec.authors       = ['Ed Robinson']
-  spec.email         = ['ed.robinson@reevoo.com']
-  spec.summary       = 'Like RuboCop only for Reevoo'
-  spec.description   = 'RuboCop patched for to enforce the use of Reevoo Style Guidelines'
-  spec.homepage      = 'http://reevoo.github.io'
-  spec.license       = 'MIT'
+  spec.authors       = ["Ed Robinson"]
+  spec.email         = ["ed.robinson@reevoo.com"]
+  spec.summary       = "Like RuboCop only for Reevoo"
+  spec.description   = "RuboCop patched for to enforce the use of Reevoo Style Guidelines"
+  spec.homepage      = "http://reevoo.github.io"
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '0.28.0'
-  spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_development_dependency 'rake'
+  spec.add_dependency "rubocop", "0.28.0"
+  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
For more in-depth analysis, see:
  https://docs.google.com/spreadsheets/d/1l0pc5pd8WlCnjfx70cD3TwrQwz_jHSnzzbClmxWjOq0/edit#gid=0

Be aware that the whitespace around blocks/methods and (particularly!)
the switch from ' to " for strings will mean that there are potentially
large reevoocop-only commits that are going to get generated in most
projects.

I can't stress enough: the quotes change is going to cause **loads of code updates** due to `'` =>`"`. Please be aware of this and make sure to commit these changes in commits outside of functional code changes.

I still think it's the right thing to do, but be warned before running reevoocop!  Unless it's possible to mark that particular change as a "warning" rather than automatically updating it somehow...?
