### PR TITLE
Upgrade rubocop to the latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+sudo: false
+dist: trusty
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in reevoocop.gemspec
 gemspec
-
-gem "pry"

--- a/Rakefile
+++ b/Rakefile
@@ -9,5 +9,5 @@ task :reevoocop_cli do
   sh "bin/reevoocop"
 end
 
-task default: [:reevoocop, :reevoocop_cli]
-task build: [:reevoocop, :reevoocop_cli]
+task default: %i[reevoocop reevoocop_cli]
+task build: %i[reevoocop reevoocop_cli]

--- a/examples/block_call.rb
+++ b/examples/block_call.rb
@@ -1,0 +1,3 @@
+def foo(&block)
+  block.call "hello" if block_given?
+end

--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -69,6 +69,9 @@ Style/TrailingCommaInArguments:
 Style/DoubleNegation:
   Enabled: false
 
+# See examples/block_call.rb
+Performance/RedundantBlockCall:
+  Enabled: false
 
 Layout/EmptyLineAfterMagicComment:
   Enabled: false

--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -19,7 +19,7 @@ EmptyLines:
 # Keeping parameters in a line makes them easier to read, but in long lines the
 # parameters look ridiculous if using the "with_first_parameter" option, making
 # it more difficult to read the code
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
 # Blank lines are useful in separating methods, specs, etc. from one another,
@@ -32,13 +32,13 @@ Style/AlignParameters:
 #     class Person
 # ... etc
 #
-Style/EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Enabled: true
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Enabled: false
-Style/EmptyLinesAroundMethodBody:
+Layout/EmptyLinesAroundMethodBody:
   Enabled: true
-Style/EmptyLinesAroundModuleBody:
+Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
 
@@ -55,17 +55,58 @@ Style/StringLiteralsInInterpolation:
 # See https://github.com/reevoo/reevoocop/issues/1
 # * For cleaner git diffs
 # * Simpler :sort:
-TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
-    - comma
-    - no_comma
 
 # See https://github.com/reevoo/reevoocop/issues/18
 # We are fine with using double negation to to force
 # something truthy or falsy to true or false
 Style/DoubleNegation:
+  Enabled: false
+
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Style/SignalException:
+  EnforcedStyle: semantic
+Style/ParallelAssignment:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Style/NestedParenthesizedCalls:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+Layout/FirstParameterIndentation:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/MethodMissing:
+  Enabled: false
+Style/IfInsideElse:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Layout/IndentHeredoc:
+  Enabled: false
+Style/StructInheritance:
+  Enabled: false
+Style/MultipleComparison:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Style/IdenticalConditionalBranches:
+  Enabled: false
+Style/VariableName:
   Enabled: false
 
 AllCops:

--- a/lib/reevoocop/rake_task.rb
+++ b/lib/reevoocop/rake_task.rb
@@ -4,21 +4,6 @@ require "rubocop/rake_task"
 
 module ReevooCop
   class RakeTask < RuboCop::RakeTask
-    def initialize(*args, &task_block) # rubocop:disable Metrics/AbcSize
-      setup_ivars(args)
-
-      desc "Run RuboCop" unless ::Rake.application.last_description
-
-      task(name, *args) do |_, task_args|
-        RakeFileUtils.send(:verbose, verbose) do
-          yield(*[self, task_args].slice(0, task_block.arity)) if block_given?
-          run_main_task(verbose)
-        end
-      end
-
-      setup_subtasks(name, *args, &task_block)
-    end
-
     def run_cli(verbose, options)
       require "reevoocop"
       super(verbose, options)

--- a/lib/reevoocop/version.rb
+++ b/lib/reevoocop/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module ReevooCop
-  VERSION = "0.0.9"
+  VERSION = "0.0.10".freeze
 end

--- a/reevoocop.gemspec
+++ b/reevoocop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "0.28.0"
+  spec.add_dependency "rubocop", "0.49.1"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Since we have been using reevoocop the the underlying version of rubocop has become outdated.

The advantages of moving to a newer rubocop are:
* More cops to choose from
* Speed - (on mark the speedup is 1.95s vs 22s to lint the full codebase)
* We can loose the monkeypatch on the Rake task

Clearly the rules that ship with rubocop have changed somewhat so I have
used the mark repo as a test suite to see what is involved, this
is because with the existing version of reevoocop mark passes on all
files.

There are 3 categories of stuff to consider:

* New cops and other changes that seem sensible and will autocorrect with `reevoocop -a` see https://github.com/reevoo/mark/commit/2f86a8361673dd7c530353c6b56d423dbdd43446 for an example
* New cops and changes that cannot be autocorrected ... see the changes to lib/reevoocop.yml for these
* Lint errors that indicate incorrect or ambiguous ruby code, these need to be fixed manualy, but we should do so https://github.com/reevoo/mark/commit/36e9fad83aa8c30991d82289ff0d0a937745e5c2