### PR TITLE
Disable Style/FrozenStringLiteralComment

### DIFF
--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -69,6 +69,9 @@ Style/TrailingCommaInArguments:
 Style/DoubleNegation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 # See examples/block_call.rb
 Performance/RedundantBlockCall:
   Enabled: false


### PR DESCRIPTION
I am working on mark and upgrading ruby to 2.3 means that this cop
is enforced, switching on frozen string literals everywhere breaks
a lot of things ... So for now lets have reevoocop not take a
stance on this.