### PR TITLE
Upgrade rubocop to 0.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: false
 dist: trusty
 language: ruby
 rvm:
-  - 2.1
   - 2.2
   - 2.3
   - 2.4
   - 2.5
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -100,7 +100,9 @@ Style/GuardClause:
   Enabled: false
 Style/RegexpLiteral:
   Enabled: false
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: false
+Style/MissingRespondToMissing:
   Enabled: false
 Style/IfInsideElse:
   Enabled: false

--- a/lib/reevoocop/version.rb
+++ b/lib/reevoocop/version.rb
@@ -1,3 +1,3 @@
 module ReevooCop
-  VERSION = "1.0.3".freeze
+  VERSION = "2.0.0".freeze
 end

--- a/reevoocop.gemspec
+++ b/reevoocop.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.54.0"
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_dependency "rubocop", "~> 0.65"
+  spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
- this change require to remove ruby 2.1 support as rubocop stopped to support is well
- it is necessary to upgrade rubocop to get support for ruby 2.6