### PR TITLE
Upgrade rubocop to 0.74

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 dist: trusty
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'

--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -94,7 +94,7 @@ Style/PercentLiteralDelimiters:
   Enabled: false
 Layout/ClosingParenthesisIndentation:
   Enabled: false
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 Style/GuardClause:
   Enabled: false

--- a/lib/reevoocop/version.rb
+++ b/lib/reevoocop/version.rb
@@ -1,3 +1,3 @@
 module ReevooCop
-  VERSION = "2.0.0".freeze
+  VERSION = "2.1.0".freeze
 end

--- a/reevoocop.gemspec
+++ b/reevoocop.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.65"
+  spec.add_dependency "rubocop", "~> 0.74"
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
- dropped support for ruby 2.2 and added support for ruby 2.6