### PR TITLE
Fix missing performance cops

### DIFF
--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 LineLength:
   Max: 120
 

--- a/lib/reevoocop/version.rb
+++ b/lib/reevoocop/version.rb
@@ -1,3 +1,3 @@
 module ReevooCop
-  VERSION = "2.1.0".freeze
+  VERSION = "2.2.0".freeze
 end

--- a/reevoocop.gemspec
+++ b/reevoocop.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.74"
+  spec.add_dependency "rubocop-performance", "~> 1.4.1"
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
- all performance cops were extracted to separated rubocop-performance project and has to be explicitely required