### PR TITLE
Fix warnings. Bump to 2.3.0

### DIFF
--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -1,6 +1,6 @@
 require: rubocop-performance
 
-LineLength:
+Metrics/LineLength:
   Max: 120
 
 # See https://github.com/reevoo/reevoocop/pull/13
@@ -9,13 +9,13 @@ LineLength:
 Metrics/MethodLength:
   Enabled: false
 
-Documentation:
+Style/Documentation:
   Enabled: false
-AndOr:
+Style/AndOr:
   Enabled: false
 
 # Allow use of empty lines to visually group code into 'paragraphs'
-EmptyLines:
+Layout/EmptyLines:
   Enabled: false
 
 # Keeping parameters in a line makes them easier to read, but in long lines the

--- a/lib/reevoocop/version.rb
+++ b/lib/reevoocop/version.rb
@@ -1,3 +1,3 @@
 module ReevooCop
-  VERSION = "2.2.0".freeze
+  VERSION = "2.3.0".freeze
 end


### PR DESCRIPTION
**It was like this:**

```
12:04 $ bin/reevoocop
/Users/maciejpalinski/reevoo/reevoocop/lib/reevoocop.yml: Warning: no department given for LineLength.
/Users/maciejpalinski/reevoo/reevoocop/lib/reevoocop.yml: Warning: no department given for Documentation.
/Users/maciejpalinski/reevoo/reevoocop/lib/reevoocop.yml: Warning: no department given for AndOr.
/Users/maciejpalinski/reevoo/reevoocop/lib/reevoocop.yml: Warning: no department given for EmptyLines.
Inspecting 8 files
........

8 files inspected, no offenses detected
```


**Now it is:**

```
12:06 $ bin/reevoocop
Inspecting 8 files
........

8 files inspected, no offenses detected
```