### PR TITLE
Bump rubocop-performance gem

### DIFF
--- a/lib/reevoocop.yml
+++ b/lib/reevoocop.yml
@@ -21,7 +21,7 @@ Layout/EmptyLines:
 # Keeping parameters in a line makes them easier to read, but in long lines the
 # parameters look ridiculous if using the "with_first_parameter" option, making
 # it more difficult to read the code
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 # Blank lines are useful in separating methods, specs, etc. from one another,
@@ -96,7 +96,7 @@ Style/PercentLiteralDelimiters:
   Enabled: false
 Layout/ClosingParenthesisIndentation:
   Enabled: false
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: false
 Style/GuardClause:
   Enabled: false
@@ -110,7 +110,7 @@ Style/IfInsideElse:
   Enabled: false
 Style/NumericPredicate:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Style/StructInheritance:
   Enabled: false

--- a/reevoocop.gemspec
+++ b/reevoocop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.74"
-  spec.add_dependency "rubocop-performance", "~> 1.4.1"
+  spec.add_dependency "rubocop-performance", "~> 1.5.1"
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
There is inconsistency between latest rubocop (0.77) and rubocop-performance (1.4.1)
```
uninitialized constant RuboCop::Cop::Performance::Count::SafeMode
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop/cop/performance/count.rb:41:in `<class:Count>'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop/cop/performance/count.rb:40:in `<module:Performance>'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop/cop/performance/count.rb:5:in `<module:Cop>'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop/cop/performance/count.rb:4:in `<module:RuboCop>'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop/cop/performance/count.rb:3:in `<top (required)>'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop/cop/performance_cops.rb:7:in `require_relative'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop/cop/performance_cops.rb:7:in `<top (required)>'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop-performance.rb:11:in `require_relative'
/usr/local/bundle/gems/rubocop-performance-1.4.1/lib/rubocop-performance.rb:11:in `<top (required)>'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/config_loader_resolver.rb:15:in `require'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/config_loader_resolver.rb:15:in `block in resolve_requires'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/config_loader_resolver.rb:11:in `each'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/config_loader_resolver.rb:11:in `resolve_requires'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/config_loader.rb:45:in `load_file'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/config_loader.rb:86:in `configuration_from_file'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/config_store.rb:44:in `for'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/cli.rb:120:in `apply_default_formatter'
/usr/local/bundle/gems/rubocop-0.77.0/lib/rubocop/cli.rb:40:in `run'
/usr/local/bundle/gems/reevoocop-2.2.0/bin/reevoocop:11:in `block in <top (required)>'
```